### PR TITLE
sci-libs/adept: Bump to 2.1.1

### DIFF
--- a/packages/sci-libs/adept/adept-2.1.1.exheres-0
+++ b/packages/sci-libs/adept/adept-2.1.1.exheres-0
@@ -19,10 +19,15 @@ MYOPTIONS="openmp"
 
 DEPENDENCIES="
     build+run:
-        sys-libs/glibc
+        openmp?     ( sys-libs/openmp )
 "
 
 DEFAULT_SRC_CONFIGURE_OPTION_ENABLES=(
     openmp
+)
+
+DEFAULT_SRC_CONFIGURE_PARAMS=(
+    --with-blas=no
+    --with-lapack=no
 )
 


### PR DESCRIPTION
* The current configuration parameters can be enabled if you require `blas` or `lapack`.

* Remove dependency on `sys-libs/glibc` and include `openmp`

Thank you,

Arch Mux