### PR TITLE
sci-libs/adept: Bump to 2.1.1

### DIFF
--- a/packages/sci-libs/adept/adept-2.1.1.exheres-0
+++ b/packages/sci-libs/adept/adept-2.1.1.exheres-0
@@ -15,14 +15,38 @@ LICENCES="Apache-2.0"
 SLOT="0"
 PLATFORMS="~amd64"
 
-MYOPTIONS="openmp"
+MYOPTIONS="
+    blas
+    lapack
+    openmp
+
+    lapack [[ requires = blas ]]
+    openmp? (
+        ( providers:
+            clang
+            gcc
+        ) [[
+            *description = [ Make sure your current compiler is selected as openmp provider ]
+            number-selected = exactly-one
+        ]]
+    )
+"
 
 DEPENDENCIES="
-    build+run:
-        sys-libs/glibc
+    blas? ( virtual/blas )
+    lapack? ( virtual/lapack )
+    openmp? (
+        providers:clang? ( sys-libs/openmp )
+        providers:gcc? ( sys-libs/libgomp )
+    )
 "
 
 DEFAULT_SRC_CONFIGURE_OPTION_ENABLES=(
     openmp
+)
+
+DEFAULT_SRC_CONFIGURE_OPTION_WITHS=(
+    blas
+    lapack
 )
 


### PR DESCRIPTION
Trying to resolve the openmp dependency from #4 and providing blas options while I'm at it.